### PR TITLE
Fixing internal Link Detecting

### DIFF
--- a/files/lib/system/event/listener/ProxyListener.class.php
+++ b/files/lib/system/event/listener/ProxyListener.class.php
@@ -46,7 +46,7 @@ class ProxyListener implements \wcf\system\event\IEventListener {
 					$localhost = true; 
 				}
 
-				if (!$localhost && !\wcf\system\application\ApplicationHandler::getInstance()->isInternalURL($match[0])) {
+				if (!$localhost && !\wcf\system\application\ApplicationHandler::getInstance()->isInternalURL($match[1])) {
 					$eventObj->message = \wcf\util\StringUtil::replaceIgnoreCase($match[0], '[img]' . $this->buildImageURL($match[1]) . "[/img]", $eventObj->message);
 				}
 			}


### PR DESCRIPTION
The ApplicationHandler should get a valid URL to validate Internal Links.
But $match[0] will contain the whole match together with the [img] tags.
So $match[1] should be used.
